### PR TITLE
Add CLI install scripts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,15 @@
+on: push
+jobs:
+  test-linux:
+    name: Test Linux
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: ShellCheck
+        uses: ludeeus/action-shellcheck@master
+        env:
+          SHELLCHECK_OPTS: --exclude SC2034,SC2086,SC2059,SC2046
+      - name: Test
+        run: |
+          cd tests
+          ./cli_unix.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,19 @@ jobs:
         uses: ludeeus/action-shellcheck@master
         env:
           SHELLCHECK_OPTS: --exclude SC2034,SC2086,SC2059,SC2046
-      - name: Test
+      - name: Run tests
         run: |
           cd tests
           ./cli_unix.sh
+  test-macos:
+    name: Test macOS
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Run tests
+        run: |
+          cd tests
+          ./cli_unix.sh
+        env:
+          # Hardcode version to avoid GitHub API rate limit in MacStadium
+          SECRETHUB_CLI_VERSION: 0.39.0

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+SC_EXCLUDES="SC2034,SC2086,SC2059,SC2046"
+
+lint:
+	@docker run -v $$(pwd):/src -w /src koalaman/shellcheck-alpine shellcheck --shell sh --exclude ${SC_EXCLUDES} cli_unix.sh

--- a/cli_unix.sh
+++ b/cli_unix.sh
@@ -56,23 +56,3 @@ curl -fsSL $LINK_TAR | $SUDO tar -xz  -C /usr/local/secrethub;
 
 # symlink in the PATH
 $SUDO ln -sf /usr/local/secrethub/bin/secrethub /usr/local/bin/secrethub
-
-if [ -d /etc/bash_completion.d/ ]; then
-    echo -e "${OK_COLOR}==> Installing completion for Bash${NO_COLOR}"
-    $SUDO sh -c "secrethub --completion-script-bash > /etc/bash_completion.d/secrethub"
-elif [ -d /usr/local/etc/bash_completion.d/ ]; then
-    echo -e "${OK_COLOR}==> Installing completion for Bash${NO_COLOR}"
-    $SUDO sh -c "secrethub --completion-script-bash > /usr/local/etc/bash_completion.d/secrethub"
-fi
-
-if command -v zsh > /dev/null 2>&1; then
-    echo -e "${OK_COLOR}==> Installing completion for ZSH${NO_COLOR}"
-    mkdir -p ~/.zsh/completion
-    secrethub --completion-script-zsh > ~/.zsh/completion/secrethub
-
-    if ! grep -q "source ~/.zsh/completion/secrethub" ~/.zshrc; then
-        echo "source ~/.zsh/completion/secrethub" >> ~/.zshrc
-    fi
-fi
-
-echo -e "${OK_COLOR}Successfully installed the SecretHub CLI.${NO_COLOR}\nTo get started, run:\n\n\tsecrethub signup";

--- a/cli_unix.sh
+++ b/cli_unix.sh
@@ -44,11 +44,13 @@ fi
 echo -e "${OK_COLOR}==> Creating directories${NO_COLOR}"
 $SUDO mkdir -p /usr/local/secrethub/bin
 
-# Retrieve latest version
-echo -e "${OK_COLOR}==> Retrieving latest version${NO_COLOR}"
-VERSION=$(curl --silent "https://api.github.com/repos/secrethub/secrethub-cli/releases/latest" | grep tag_name | awk -F\" '{ print $4 }')
+if [ "${SECRETHUB_CLI_VERSION:-latest}" != "latest" ]; then
+    VERSION=v${SECRETHUB_CLI_VERSION}
+else
+    # Retrieve latest version
+    VERSION=$(curl --silent "https://api.github.com/repos/secrethub/secrethub-cli/releases/latest" | grep tag_name | awk -F\" '{ print $4 }')
+fi
 
-echo -e "${OK_COLOR}==> Downloading latest version${NO_COLOR}"
 ARCHIVE_NAME=secrethub-$VERSION-$OS-$ARCH
 LINK_TAR=https://github.com/secrethub/secrethub-cli/releases/download/$VERSION/$ARCHIVE_NAME.tar.gz
 

--- a/cli_unix.sh
+++ b/cli_unix.sh
@@ -1,5 +1,4 @@
-#!/bin/bash
-
+#!/bin/sh
 set -e
 
 # Colors
@@ -8,58 +7,56 @@ OK_COLOR="\033[32;01m"
 ERROR_COLOR="\033[31;01m"
 WARN_COLOR="\033[33;01m"
 
-# Detect Architecture
+# Detect architecture
 ARCH=amd64
-if [ $(getconf LONG_BIT) == 32 ]; then
+if [ $(getconf LONG_BIT) = 32 ]; then
     ARCH=386
 fi
 
 # Detect OS
 UNAME=$(uname)
-if [[ "$UNAME" == "Darwin" ]]; then
-	OS=darwin
-elif [[ $UNAME == "Linux" ]]; then
+if [ "$UNAME" = "Darwin" ]; then
+    OS=darwin
+elif [ "$UNAME" = "Linux" ]; then
     OS=linux
 else
-    echo -e "${ERROR_COLOR}Cannot determine OS type. Exiting...${NO_COLOR}"
+    printf "${ERROR_COLOR}Cannot determine OS type. Exiting...${NO_COLOR}\n"
     exit;
 fi
 
-# Make sure we have root priviliges.
+# Make sure we have root privileges if necessary
 SUDO=""
-if [[ $(id -u) -ne 0 ]]; then
-    if ! [[ $(command -v sudo) ]]; then
-        echo -e "${ERROR_COLOR}Installer requires root privileges. Please run this script as root.${NO_COLOR}"
+if [ $(id -u) -ne 0 ]; then
+    if ! [ $(command -v sudo) ]; then
+        printf "${ERROR_COLOR}Installer requires root privileges. Please run this script as root.${NO_COLOR}\n"
         exit;
-    fi
-
-    if ! sudo -n true 2>/dev/null; then
-        echo -e "${OK_COLOR}==> I need root privileges to continue, please type in your password.${NO_COLOR}"
-        sudo -v
     fi
 
     SUDO="sudo"
 fi
 
-echo -e "${OK_COLOR}==> Creating directories${NO_COLOR}"
+printf "${OK_COLOR}==> Creating directories${NO_COLOR}\n"
 $SUDO mkdir -p /usr/local/secrethub/bin
 
 if [ "${SECRETHUB_CLI_VERSION:-latest}" != "latest" ]; then
     VERSION=v${SECRETHUB_CLI_VERSION}
 else
     # Retrieve latest version
+    printf "${OK_COLOR}==> Retrieving latest version${NO_COLOR}\n"
     VERSION=$(curl --silent "https://api.github.com/repos/secrethub/secrethub-cli/releases/latest" | grep tag_name | awk -F\" '{ print $4 }')
 fi
 
 # Exit if version is already installed
 if command -v secrethub >/dev/null 2>&1 && secrethub --version 2>&1 | cut -d "," -f 1 | grep -q "$(echo $VERSION | cut -c 2-)$"; then
+    printf "${OK_COLOR}==> Version ${VERSION} is already installed${NO_COLOR}\n"
     exit 0
 fi
 
+printf "${OK_COLOR}==> Downloading version ${VERSION}${NO_COLOR}\n"
 ARCHIVE_NAME=secrethub-$VERSION-$OS-$ARCH
 LINK_TAR=https://github.com/secrethub/secrethub-cli/releases/download/$VERSION/$ARCHIVE_NAME.tar.gz
 
-curl -fsSL $LINK_TAR | $SUDO tar -xz  -C /usr/local/secrethub;
+curl -fsSL $LINK_TAR | $SUDO tar -xz -C /usr/local/secrethub;
 
-# symlink in the PATH
+# Create symlink to add binary to $PATH
 $SUDO ln -sf /usr/local/secrethub/bin/secrethub /usr/local/bin/secrethub

--- a/cli_unix.sh
+++ b/cli_unix.sh
@@ -43,7 +43,7 @@ if [ "${SECRETHUB_CLI_VERSION:-latest}" != "latest" ]; then
 else
     # Retrieve latest version
     printf "${OK_COLOR}==> Retrieving latest version${NO_COLOR}\n"
-    VERSION=$(curl --silent "https://api.github.com/repos/secrethub/secrethub-cli/releases/latest" | grep tag_name | awk -F\" '{ print $4 }')
+    VERSION=$(curl -sSf "https://api.github.com/repos/secrethub/secrethub-cli/releases/latest" | grep tag_name | awk -F\" '{ print $4 }')
 fi
 
 # Exit if version is already installed

--- a/cli_unix.sh
+++ b/cli_unix.sh
@@ -51,6 +51,11 @@ else
     VERSION=$(curl --silent "https://api.github.com/repos/secrethub/secrethub-cli/releases/latest" | grep tag_name | awk -F\" '{ print $4 }')
 fi
 
+# Exit if version is already installed
+if command -v secrethub >/dev/null 2>&1 && secrethub --version 2>&1 | cut -d "," -f 1 | grep -q "$(echo $VERSION | cut -c 2-)$"; then
+    exit 0
+fi
+
 ARCHIVE_NAME=secrethub-$VERSION-$OS-$ARCH
 LINK_TAR=https://github.com/secrethub/secrethub-cli/releases/download/$VERSION/$ARCHIVE_NAME.tar.gz
 

--- a/cli_unix.sh
+++ b/cli_unix.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+set -e
+
+# Colors
+NO_COLOR="\033[0m"
+OK_COLOR="\033[32;01m"
+ERROR_COLOR="\033[31;01m"
+WARN_COLOR="\033[33;01m"
+
+# Detect Architecture
+ARCH=amd64
+if [ $(getconf LONG_BIT) == 32 ]; then
+    ARCH=386
+fi
+
+# Detect OS
+UNAME=$(uname)
+if [[ "$UNAME" == "Darwin" ]]; then
+	OS=darwin
+elif [[ $UNAME == "Linux" ]]; then
+    OS=linux
+else
+    echo -e "${ERROR_COLOR}Cannot determine OS type. Exiting...${NO_COLOR}"
+    exit;
+fi
+
+# Make sure we have root priviliges.
+SUDO=""
+if [[ $(id -u) -ne 0 ]]; then
+    if ! [[ $(command -v sudo) ]]; then
+        echo -e "${ERROR_COLOR}Installer requires root privileges. Please run this script as root.${NO_COLOR}"
+        exit;
+    fi
+
+    if ! sudo -n true 2>/dev/null; then
+        echo -e "${OK_COLOR}==> I need root privileges to continue, please type in your password.${NO_COLOR}"
+        sudo -v
+    fi
+
+    SUDO="sudo"
+fi
+
+echo -e "${OK_COLOR}==> Creating directories${NO_COLOR}"
+$SUDO mkdir -p /usr/local/secrethub/bin
+
+# Retrieve latest version
+echo -e "${OK_COLOR}==> Retrieving latest version${NO_COLOR}"
+VERSION=$(curl --silent "https://api.github.com/repos/secrethub/secrethub-cli/releases/latest" | grep tag_name | awk -F\" '{ print $4 }')
+
+echo -e "${OK_COLOR}==> Downloading latest version${NO_COLOR}"
+ARCHIVE_NAME=secrethub-$VERSION-$OS-$ARCH
+LINK_TAR=https://github.com/secrethub/secrethub-cli/releases/download/$VERSION/$ARCHIVE_NAME.tar.gz
+
+curl -fsSL $LINK_TAR | $SUDO tar -xz  -C /usr/local/secrethub;
+
+# symlink in the PATH
+$SUDO ln -sf /usr/local/secrethub/bin/secrethub /usr/local/bin/secrethub
+
+if [ -d /etc/bash_completion.d/ ]; then
+    echo -e "${OK_COLOR}==> Installing completion for Bash${NO_COLOR}"
+    $SUDO sh -c "secrethub --completion-script-bash > /etc/bash_completion.d/secrethub"
+elif [ -d /usr/local/etc/bash_completion.d/ ]; then
+    echo -e "${OK_COLOR}==> Installing completion for Bash${NO_COLOR}"
+    $SUDO sh -c "secrethub --completion-script-bash > /usr/local/etc/bash_completion.d/secrethub"
+fi
+
+if command -v zsh > /dev/null 2>&1; then
+    echo -e "${OK_COLOR}==> Installing completion for ZSH${NO_COLOR}"
+    mkdir -p ~/.zsh/completion
+    secrethub --completion-script-zsh > ~/.zsh/completion/secrethub
+
+    if ! grep -q "source ~/.zsh/completion/secrethub" ~/.zshrc; then
+        echo "source ~/.zsh/completion/secrethub" >> ~/.zshrc
+    fi
+fi
+
+echo -e "${OK_COLOR}Successfully installed the SecretHub CLI.${NO_COLOR}\nTo get started, run:\n\n\tsecrethub signup";

--- a/cli_windows.ps1
+++ b/cli_windows.ps1
@@ -1,0 +1,73 @@
+param (
+    [string]$DownloadBaseURL = 'https://github.com/secrethub/secrethub-cli/releases/download/',
+    [string]$InstallPath,
+    [string]$InstallDir = 'SecretHub',
+    [string]$OS = "windows",
+    [string]$ApplicationName = "SecretHub CLI",
+    [string]$BinaryName = "secrethub"
+ )
+
+$ErrorActionPreference = "Stop"
+
+echo "This script will install the latest version of the $ApplicationName."
+
+If(!$InstallPath) {
+    $programFilesDir = [environment]::getfolderpath("ProgramFiles")
+    $InstallPath = Join-Path $programFilesDir $InstallDir
+}
+
+$licensePath = Join-Path $InstallPath LICENSE
+
+If(!(test-path $InstallPath)){
+    mkdir $InstallPath | out-null
+}
+
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+$releases = "https://api.github.com/repos/secrethub/secrethub-cli/releases"
+$version = (Invoke-WebRequest $releases | ConvertFrom-Json)[0].tag_name
+
+# This will either suffix the OS with `amd64` (64-bit) or 
+# `x86` (32-bit), depending on the architecture.
+$ARCH = $ENV:PROCESSOR_ARCHITECTURE.ToLower()
+$archiveName = $BinaryName + '-' + $version + '-' + $OS + '-' + $ARCH
+
+# download
+$archive = $archiveName + '.zip'
+$archiveURL = $DownloadBaseURL + $version + '/' + $archive
+$archiveFile = $ENV:TEMP + '\'+ $archive
+(New-Object System.Net.WebClient).DownloadFile($archiveURL, [IO.Path]::GetFullPath($archiveFile))
+
+# unzip
+$shell = new-object -com shell.application
+$source = $shell.NameSpace([IO.Path]::GetFullPath($archiveFile))
+$dest = $shell.Namespace([IO.Path]::GetFullPath($InstallPath))
+$dest.CopyHere($source.items(), 0x14)
+
+# Cleanup
+rm $archiveFile
+$oldBinary = Join-Path -Path $InstallPath -ChildPath "secrethub.exe"
+if (Test-Path $oldBinary)
+{
+  Remove-Item $oldBinary
+}
+
+# Adding SecretHub folder to Path...
+# Check if already in Path
+$envPaths = $env:Path -split ';'
+$bin = Join-Path -Path $InstallPath -ChildPath "bin"
+if ($envPaths -notcontains $bin) {
+    $envPaths = $envPaths + $bin | where { $_ }
+    $newPath = $envPaths -join ';'
+
+    # Add it to the Path
+    [Environment]::SetEnvironmentVariable("Path", $newPath, [EnvironmentVariableTarget]::User)
+
+    # Refresh the Path
+    $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")
+}
+
+echo "Successfully installed $ApplicationName $version. To verify the installation, run: 
+
+    $BinaryName --version
+    
+"

--- a/tests/cli_unix.sh
+++ b/tests/cli_unix.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+
+../cli_unix.sh
+secrethub --version
+
+export SECRETHUB_CLI_VERSION=0.39.0
+../cli_unix.sh
+secrethub --version 2>&1 | grep "0.39.0"


### PR DESCRIPTION
Here are the CLI install script modifications I did for the CircleCI orb to support versioning.

Now that we want to use it for ~~NPM too (as a Git submodule) as well as~~ future (CI) integrations I've created a repo for it.

It will also allow for static links with a commit hash, making a curl-pipe-to-sh a little bit more trustworthy, e.g.: 
`curl https://raw.githubusercontent.com/secrethub/install-scripts/217358495fc965dbd42099a606f9852101476dc1/cli_unix.sh | sh`

### TO-DO
- [ ] Add support for version pinning in Windows. We basically need f345d7b61624434ccc240e33eb298e6ee4a7f631, but then in the PowerShell script.
- [ ] Add test for Windows. See [./.github/workflows/test.yml](https://github.com/secrethub/install-scripts/blob/e477132abe2092bd4e7ab33d3f6ca085476c003a/.github/workflows/test.yml).
- [ ] (Optional) Don't install Windows version if it already exists. 33e9dc48b88c52cb5ef1847f3cd79e63d5852981, but then in PowerShell.